### PR TITLE
Allow overriding autocomplete options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ API Response
 To install this package, run the following command in an existing strapi project:
 
 ```sh
-npm install strapi-location-field-plugin 
+npm install strapi-location-field-plugin
 ```
 
 ## Usage
@@ -28,19 +28,35 @@ module.exports = {
     enabled: true,
     config: {
       fields: ["photo", "rating"], // optional
-      googleMapsApiKey: "your google api key", //You need to enable "Autocomplete API" and "Places API" in your Google Cloud Console
+      // You need to enable "Autocomplete API" and "Places API" in your Google Cloud Console
+      googleMapsApiKey: env("GOOGLE_MAPS_API_KEY"),
+      // See https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest
+      autocompletionRequestOptions: {},
     },
   },
   // .. your other plugin configurations
 };
 ```
-> :warning: It is strongly recommended to store your API key using an environment variable and not directly in plugins.js.
 
-Note: the config.fields value can be set to an array of options (strings) containing any fields you'd like to be returned. The options that Google allows can be found [here](https://developers.google.com/maps/documentation/places/web-service/details) or in the screenshot below.  When set, the information relevant to those specific fields will be accessible in the API response under the "details" key.  The "geometry" field is enabled by default.
+Note: the `config.fields` value can be set to an array of options (strings) containing any fields you'd like to be returned. The options that Google allows can be found [here](https://developers.google.com/maps/documentation/places/web-service/details) or in the screenshot below.  When set, the information relevant to those specific fields will be accessible in the API response under the "details" key.  The `geometry` field is always enabled.
 
 ![image](https://user-images.githubusercontent.com/29098307/228680235-992c95c5-5b22-4ce1-9128-188825831e51.png)
 
-> ℹ️ Please note: some fields may not return the expected response.  Currently only the "photo", "rating", and "geometry" fields have been tested.
+> ℹ️ Please note: some fields may not return the expected response.  Currently only the `photo`, `rating`, and `geometry` fields have been tested.
+
+`autocompletionRequestOptions` allows you to customize the search behavior by overriding the options used when autocompletion requests are made. The [Autocomplete API documentation](https://developers.google.com/maps/documentation/javascript/reference/places-autocomplete-service#AutocompletionRequest) lists all the available options. For example, this configuration returns autocomplete results in Spanish and biases the search closer to the caller's IP address:
+
+```javascript
+{
+  config: {
+    googleMapsApiKey: env("GOOGLE_MAPS_API_KEY"),
+    autocompletionRequestOptions: {
+      language: 'es',
+      locationBias: 'IP_BIAS',
+    },
+  },
+}
+```
 
 
 You'll also need to modify the `/config/middlewares.js` file

--- a/admin/src/components/LocationInput.js
+++ b/admin/src/components/LocationInput.js
@@ -15,14 +15,15 @@ export default function Input({ onChange, value, name, attribute, error, require
   const [apiKey, setApiKey] = useState(null);
   const [fields, setFields] = useState(null);
   const [loader, setLoader] = useState(null);
+  const [autocompletionRequestOptions, setAutocompletionRequestOptions] = useState(null);
 
   const getConfigDetails = async () => {
     const { signal } = new AbortController();
-    const { fields, googleMapsApiKey } = await request("/location-field/config", {
+    const { fields, autocompletionRequestOptions, googleMapsApiKey } = await request("/location-field/config", {
       method: "GET",
       signal,
     });
-    return { fields, googleMapsApiKey };
+    return { fields, autocompletionRequestOptions, googleMapsApiKey };
   };
 
   React.useEffect(() => {
@@ -33,6 +34,7 @@ export default function Input({ onChange, value, name, attribute, error, require
         config.fields.push("geometry");
       }
       setFields(config.fields);
+      setAutocompletionRequestOptions(config.autocompletionRequestOptions);
     });
   }, []);
 
@@ -75,7 +77,7 @@ export default function Input({ onChange, value, name, attribute, error, require
         let sessionToken = new google.maps.places.AutocompleteSessionToken();
         let service = new google.maps.places.AutocompleteService();
         service.getPlacePredictions(
-          { input: e.target.value, sessionToken: sessionToken },
+          { ...autocompletionRequestOptions, input: e.target.value, sessionToken: sessionToken },
           (predictions, status) => {
             if (status !== google.maps.places.PlacesServiceStatus.OK) {
               console.error(status);
@@ -103,14 +105,13 @@ export default function Input({ onChange, value, name, attribute, error, require
             console.error(status);
             return;
           }
-          
           // if "photo" is in the fields array, call "getUrl()" for each photo in the response
           if (fields.includes("photo") && place?.photos) {
             place.photos.forEach((photo) => {
               photo.url = photo.getUrl();
             });
           }
-          
+
           selectedPrediction.details = place;
 
           targetValue = JSON.stringify({


### PR DESCRIPTION
Hi @raykeating, thanks for this plugin. Here's a PR to allow overriding arbitrary options. In my case, I wanted to save results in a different language for all users.

I'm sure there's a lot more complicated things that can be done with languages (searching results in one language but saving them in another, dynamically selecting languages based on multiple factors, etc) but this should be a good starting point that can work as an escape hatch if more complex behavior is added later on.

Open to suggestions if you can come up with a better name than `autocompletionRequestOptions` - I chose that since it diretly mentions Google's `AutocompletionRequest` type.

Here's an example query with new settings:

```typescript
// plugins.ts
export default ({env}) => ({
    'location-field': {
        enabled: true,
        resolve: './strapi-location-field-plugin',
        config: {
            fields: ['geometry', 'address_component'],
            googleMapsApiKey: env('GOOGLE_MAPS_API_KEY'),
            autocompletionRequestOptions: {
                language: 'es-419',
                locationBias: 'IP_BIAS',
                region: 'AR',
            }
        },
    },
});
```

![Screenshot_20230509_041014](https://user-images.githubusercontent.com/829698/237022353-8faac98b-95c9-4bbb-b27f-832b9900c1ad.png)

